### PR TITLE
Bug Fixes

### DIFF
--- a/src/forms/backcraft/b_backups.Designer.cs
+++ b/src/forms/backcraft/b_backups.Designer.cs
@@ -129,6 +129,7 @@
             this.textbox_path.Name = "textbox_path";
             this.textbox_path.Size = new System.Drawing.Size(173, 20);
             this.textbox_path.TabIndex = 3;
+            this.textbox_path.TextChanged += new System.EventHandler(this.textbox_path_TextChanged);
             // 
             // label2
             // 

--- a/src/forms/backcraft/b_backups.cs
+++ b/src/forms/backcraft/b_backups.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
 using System.Drawing;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -39,31 +40,12 @@ namespace backcraft.forms.backcraft
             gridview_backups.RowHeadersVisible = false;
             col2.Width = 100;
 
+            LoadSavePathList();
         }
 
         private void btn_load_Click(object sender, EventArgs e)
         {
-            gridview_backups.Rows.Clear();
-
-            try
-            {
-                List<string> l = logic.paths.GetPaths();
-
-                foreach (string s in l)
-                {
-                    gridview_backups.Rows.Add(s, "Delete");
-                }
-            }
-            catch (Exception)
-            {
-            }
-
-            btn_add.Enabled = true;
-            btn_search.Enabled = true;
-            btn_save.Enabled = true;
-            gridview_backups.Enabled = true;
-            textbox_path.Enabled = true;
-
+            LoadSavePathList();
         }
 
         private void btn_search_Click(object sender, EventArgs e)
@@ -77,7 +59,17 @@ namespace backcraft.forms.backcraft
 
         private void btn_add_Click(object sender, EventArgs e)
         {
-            gridview_backups.Rows.Add(textbox_path.Text.ToString(), "Delete");
+            if (textbox_path.Text != string.Empty)
+            {   // Add path if exists.
+                if (Directory.Exists(textbox_path.Text))
+                {
+                    gridview_backups.Rows.Add(textbox_path.Text.ToString(), "Delete");
+                }
+                else
+                {
+                    MessageBox.Show("Path does not exist!", "Error");
+                }
+            }
         }
 
         private void btn_save_Click(object sender, EventArgs e)
@@ -114,15 +106,50 @@ namespace backcraft.forms.backcraft
         {
             if (gridview_backups.Columns[e.ColumnIndex].Name == "delete")
             {
-                gridview_backups.Rows.RemoveAt(e.RowIndex);
                 try
                 {
                     new logic.paths().DeleteFromFile(gridview_backups.Rows[e.RowIndex].Cells[0].Value.ToString());
-
+                    gridview_backups.Rows.RemoveAt(e.RowIndex);
                 }
                 catch (Exception)
                 {
                 }
+            }
+        }
+
+        private void LoadSavePathList()
+        {
+            gridview_backups.Rows.Clear();
+
+            try
+            {
+                List<string> l = logic.paths.GetPaths();
+
+                foreach (string s in l)
+                {
+                    gridview_backups.Rows.Add(s, "Delete");
+                }
+            }
+            catch (Exception)
+            {
+            }
+
+
+            btn_search.Enabled = true;
+            btn_save.Enabled = true;
+            gridview_backups.Enabled = true;
+            textbox_path.Enabled = true;
+        }
+
+        private void textbox_path_TextChanged(object sender, EventArgs e)
+        {
+            if (textbox_path.Text != string.Empty)
+            {
+                btn_add.Enabled = true;
+            }
+            else
+            {
+                btn_add.Enabled = false;
             }
         }
     }

--- a/src/forms/minecraft/m_saves.cs
+++ b/src/forms/minecraft/m_saves.cs
@@ -45,9 +45,49 @@ namespace backcraft.forms.minecraft
 
             gridview_worlds.RowHeadersVisible = false;
             col3.Width = 50;
+
+            LoadWorldList();
         }
 
         private void btn_loadworlds_Click(object sender, EventArgs e)
+        {
+            LoadWorldList();
+        }
+
+        private void btn_save_Click(object sender, EventArgs e)
+        {
+
+            foreach (DataGridViewRow r in gridview_worlds.Rows)
+            {
+                string name = r.Cells[0].Value.ToString();
+                string path = r.Cells[1].Value.ToString();
+                string check = r.Cells[2].Value.ToString();
+                if (Convert.ToBoolean(check))
+                {
+                    new logic.files(name, path, "d").WriteCFG();
+                }
+                else
+                {
+                    try
+                    {
+                        new logic.files().DeleteFromFile(name, path);
+                    }
+                    catch (Exception)
+                    {
+                    }
+                }
+
+            }
+
+            this.Close();
+        }
+
+        private void btn_cancel_Click(object sender, EventArgs e)
+        {
+            this.Close();
+        }
+
+        private void LoadWorldList()
         {
             gridview_worlds.Rows.Clear();
 
@@ -94,42 +134,7 @@ namespace backcraft.forms.minecraft
             {
                 MessageBox.Show("Error getting the folders from the path! Check out that the Minecraft path is correct or if there are files inside the folder!", "Backcraft");
             }
-
         }
-
-        private void btn_save_Click(object sender, EventArgs e)
-        {
-
-            foreach (DataGridViewRow r in gridview_worlds.Rows)
-            {
-                string name = r.Cells[0].Value.ToString();
-                string path = r.Cells[1].Value.ToString();
-                string check = r.Cells[2].Value.ToString();
-                if (Convert.ToBoolean(check))
-                {
-                    new logic.files(name, path, "d").WriteCFG();
-                }
-                else
-                {
-                    try
-                    {
-                        new logic.files().DeleteFromFile(name, path);
-                    }
-                    catch (Exception)
-                    {
-                    }
-                }
-
-            }
-
-            this.Close();
-        }
-
-        private void btn_cancel_Click(object sender, EventArgs e)
-        {
-            this.Close();
-        }
-
 
     }
 }

--- a/src/logic/files.cs
+++ b/src/logic/files.cs
@@ -136,6 +136,12 @@ namespace backcraft.logic
         {
             List<files> files = new List<logic.files>();
 
+            //If file doese not exist, create empty file and close writer
+            if (!File.Exists(_txtfile))
+            {
+                File.Create(_txtfile).Dispose();
+            }
+
             using (StreamReader rd = new StreamReader(_txtfile, true))
             {
 


### PR DESCRIPTION
_WorldList and Backup Path List updates._

**WorldList :**  
- Load worlds on form open event.
- Create 'files.txt' when requested if no file exists

**Backup Path List :**

- Load paths on form open event. 
- Add path only if path text is not empty and if path exists (BugFix) 
- Delete row AFTER it has been removed from saved file, otherwise the index can be wrong (BugFix) 
- Disable Add Button it path text is empty
